### PR TITLE
Update Slack link to use https

### DIFF
--- a/target/index.html
+++ b/target/index.html
@@ -56,12 +56,12 @@
       <a href="./" id="swcraft-title" class="brand-logo center">Software Crafters</a>
       <a href="#" data-activates="mobile-demo" class="button-collapse"><i class="fa fa-bars"></i></a>
       <ul id="nav-mobile" class="right hide-on-med-and-down">
-        <li><a href="http://slack.softwarecrafters.org/"><i class="fa fa-slack">&nbsp;</i>Slack</a></li>
+        <li><a href="https://slack.softwarecrafters.org/"><i class="fa fa-slack">&nbsp;</i>Slack</a></li>
         <li><a href="https://github.com/softwarecrafters/website"><i class="fa fa-github">&nbsp;</i>Add your community</a></li>
         <li><a href="#start-a-community" class="modal-trigger"><i class="fa fa-star">&nbsp;</i>Start a community</a></li>
       </ul>
       <ul class="side-nav" id="mobile-demo">
-        <li><a href="http://slack.softwarecrafters.org/"><i class="fa fa-slack">&nbsp;</i>Join the Slack team</a></li>
+        <li><a href="https://slack.softwarecrafters.org/"><i class="fa fa-slack">&nbsp;</i>Join the Slack team</a></li>
         <li><a href="https://github.com/softwarecrafters/website"><i class="fa fa-github">&nbsp;</i>Add your community</a></li>
         <li><a href="#start-a-community" class="modal-trigger"><i class="fa fa-star">&nbsp;</i>Start a community</a></li>
         <li><a href="#imprint" class="modal-trigger">Imprint</a></li>
@@ -99,7 +99,7 @@ Pappelallee 78/79
       <h4>Start a local community</h4>
       <p>Didn&quot;t find a local community near you? Why not start one! For the first meeting, all you need are two passionate people.</p>
       <p>We have a channel, <code>#orgasunited</code> (<a target="_blank" href="slack://channel?id=C0A94BHG9&team=T0A7W9V7C"><i class="fa fa-slack">&nbsp;</i>In-App</a> / <a target="_blank" href="https://softwarecrafters.slack.com/messages/C0A94BHG9/"><i class="fa fa-globe">&nbsp;</i>Web</a>), where you can find seasoned community organizers who are happy to share their experience and their insights with you.
-        <br/>If you have not joined the <em>Software Crafters Slack Team</em> yet, click <a target="_blank" href="http://slack.softwarecrafters.org"><i class="fa fa-envelope-o">&nbsp;</i>here</a> to join
+        <br/>If you have not joined the <em>Software Crafters Slack Team</em> yet, click <a target="_blank" href="https://slack.softwarecrafters.org"><i class="fa fa-envelope-o">&nbsp;</i>here</a> to join
       </p>
       <p>Right below, we listed some further readings for you about running meetups</p>
       <ul>


### PR DESCRIPTION
There seems to be a HTTPS version of the Slack signup page so it should probably be using instead of the HTTP one.