### PR TITLE
Add Seattle Software Crafters group

### DIFF
--- a/communities/seattle.json
+++ b/communities/seattle.json
@@ -1,0 +1,8 @@
+{
+  "name": "Seattle Software Crafters",
+  "url": "https://www.meetup.com/seattle-software-craftsmanship/",
+  "location": {
+    "city": "Seattle, WA, USA",
+    "coordinates": [-122.3312136045949, 47.60371401067161]
+  }
+}


### PR DESCRIPTION
This PR adds the Seattle Software Crafters group: https://www.meetup.com/seattle-software-craftsmanship/