### PR TITLE
Adding Vienna Crafters group (Softwerkskammer Wien)

### DIFF
--- a/communities/vienna-softwerkskammer.json
+++ b/communities/vienna-softwerkskammer.json
@@ -1,0 +1,8 @@
+{
+  "name": "Softwerkskammer Wien",
+  "url": "https://www.softwerkskammer.org/groups/wien",
+  "location": {
+    "city": "Vienna, Austria",
+    "coordinates": [16.39285350357477,48.19990958622796]
+  }
+}


### PR DESCRIPTION
I would like to add the Vienna crafters group (Softwerkskammer Wien) to the website.