### PR TITLE
Add Manchester and New York to the Software Crafters communities

### DIFF
--- a/communities/manchester.json
+++ b/communities/manchester.json
@@ -1,0 +1,8 @@
+{
+  "name": "Software Crafters North",
+  "url": "https://www.meetup.com/software-crafters-north/",
+  "location": {
+    "city": "Manchester, United Kingdom",
+    "coordinates": { "lat": 53.47781211493378, "lng": -2.256247743256921 }
+  }
+}

--- a/communities/new-york.json
+++ b/communities/new-york.json
@@ -1,0 +1,8 @@
+{
+  "name": "Software Craftsmanship New York",
+  "url": "https://www.meetup.com/software-craftsmanship-new-york/",
+  "location": {
+    "city": "New York, NY, USA",
+    "coordinates": { "lat": 40.70722937083664, "lng": -74.00919539967515 }
+  }
+}


### PR DESCRIPTION
Adding an entry for the Manchester "Software Crafters North" community and New York "New York Software Craftsmanship" community.