### PR TITLE
Update Montreal community URL

### DIFF
--- a/communities/montreal.json
+++ b/communities/montreal.json
@@ -1,6 +1,6 @@
 {
   "name": "Software Crafters Montreal",
-  "url": "https://www.meetup.com/Software-Crafters-Montreal/",
+  "url": "https://guild.host/software-crafters-montreal",
   "location": {
     "city": "Montreal, QC, Canada",
     "coordinates": { "lat": 45.52663715669149, "lng": -73.60701487863523 }


### PR DESCRIPTION
We are migrating the community from Meetup to Guild Host—Meetup.com is becoming expensive and Guild Host seems a great alternative for us (free for organizers).

The Luxembourg community is already on here: https://guild.host/software-craft-luxembourg/events

And we have created a "Software Crafters" network: https://guild.host/software-craftsmanship/network



