### PR TITLE
Paris dojo have migrated to Mobilizon instead of Meetup

### DIFF
--- a/communities/paris-dojo-programmation.json
+++ b/communities/paris-dojo-programmation.json
@@ -1,6 +1,6 @@
 {
-  "name": "Dojo Développement de Paris",
-  "url": "https://www.meetup.com/dojo-developpement-paris",
+  "name": "Dojo de programmation Paris",
+  "url": "https://mobilizon.fr/@dojo_de_programmation_paris",
   "location": {
     "city": "Paris, France",
     "coordinates": { "lat": 48.86691942715075, "lng": 2.3494235888259425 }


### PR DESCRIPTION
Also we have changed the name "development" with "programmation"

https://github.com/dojo-developpement-paris/dojo-developpement-paris.github.io/issues/35