### PR TITLE
check URL of communities

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "npm-run-all test:data test:js",
     "test:data": "node scripts/test-communities.js && node scripts/test-conferences.js",
     "test:js": "jest",
+    "test:data:url": "node scripts/test-communities-check-url.mjs",
     "watch": "npm-run-all build:communities build:conferences build:conferences-ics -p dev"
   },
   "jest": {

--- a/scripts/test-communities-check-url.mjs
+++ b/scripts/test-communities-check-url.mjs
@@ -1,0 +1,24 @@
+import path from 'path';
+import fs from 'fs';
+
+const communitiesDir = path.resolve(import.meta.dirname, '../communities/');
+
+const communitiesPath = fs
+  .readdirSync(communitiesDir)
+  .filter(file => file.endsWith('.json'))
+  .map(file => path.join(communitiesDir, file));
+
+const communities = communitiesPath
+  .map(file => fs.readFileSync(file).toString())
+  .map(fileContent => JSON.parse(fileContent));
+
+const fetchCommunities = communities.map(community => fetch(community.url));
+
+const failedURL = (await Promise.all(fetchCommunities))
+  .filter(communityResponse => !communityResponse.ok)
+  .map(communityResponse => communityResponse.url);
+
+if (failedURL.length > 0) {
+  console.log(failedURL);
+  process.exit(1);
+}

--- a/scripts/test-communities-check-url.mjs
+++ b/scripts/test-communities-check-url.mjs
@@ -14,9 +14,27 @@ const communities = communitiesPath
 
 const fetchCommunities = communities.map(community => fetch(community.url));
 
-const failedURL = (await Promise.all(fetchCommunities))
+const communitiesResponses = await Promise.all(fetchCommunities);
+
+const failedURLNotOK = communitiesResponses
   .filter(communityResponse => !communityResponse.ok)
   .map(communityResponse => communityResponse.url);
+
+// meetup.com answer with HTTP 200 when a group is not found
+const meetupGroupsNotFound = (
+  await Promise.all(
+    communitiesResponses
+      .filter(communityResponse => communityResponse.ok)
+      .map(async communityResponse => {
+        const communityHTML = await communityResponse.text();
+        return /<title[^>]*>Meetup | Group not found<\/title>/.test(communityHTML)
+          ? communityResponse.url
+          : null;
+      })
+  )
+).filter(maybeURL => maybeURL !== null);
+
+const failedURL = failedURLNotOK.concat(meetupGroupsNotFound);
 
 if (failedURL.length > 0) {
   console.log(failedURL);

--- a/scripts/test-communities-check-url.mjs
+++ b/scripts/test-communities-check-url.mjs
@@ -38,5 +38,6 @@ const failedURL = failedURLNotOK.concat(meetupGroupsNotFound);
 
 if (failedURL.length > 0) {
   console.log(failedURL);
+  console.log('%i communities URL are failing on a total of %i', failedURL.length, communitiesPath.length);
   process.exit(1);
 }

--- a/scripts/test-communities-check-url.mjs
+++ b/scripts/test-communities-check-url.mjs
@@ -37,7 +37,6 @@ const meetupGroupsNotFound = (
 const failedURL = failedURLNotOK.concat(meetupGroupsNotFound);
 
 if (failedURL.length > 0) {
-  console.log(failedURL);
-  console.log('%i communities URL are failing on a total of %i', failedURL.length, communitiesPath.length);
+  console.log({ failedURL, failedURLCount: failedURL.length, total: communitiesPath.length });
   process.exit(1);
 }


### PR DESCRIPTION
Add a script that checks whether the communities URL can be retrieved or not

Don’t detect the group that died from Meetup because, as always: Meetup is disappointing : it returns a 200 when a group no longer exists

This is a first step for #259 

Not sure if i should add it to `npm test`