### PR TITLE
Istanbul: update URL

### DIFF
--- a/communities/istanbul.json
+++ b/communities/istanbul.json
@@ -1,6 +1,6 @@
 {
-  "name": "Software Craftsmanship Turkey - SCTurkey",
-  "url": "https://www.meetup.com/Software-Craftsmanship-Turkey/",
+  "name": "Istanbul Software Craftsmanship",
+  "url": "https://www.meetup.com/istanbul-software-craftsmanship/",
   "location": {
     "city": "Istanbul, Turkey",
     "coordinates": { "lat": 41.00631454633913, "lng": 29.073189655346084 }


### PR DESCRIPTION
the group was named by the contry instead of the city

the new group seems not active but the page still exists (so someone continue to pay for it)

i'm not sure if they are the same group

Found with #269 